### PR TITLE
Added support for Flickr API authentication and also added FLICKR_SETS_INCLUDE

### DIFF
--- a/pelican-flickr/main.py
+++ b/pelican-flickr/main.py
@@ -26,6 +26,10 @@ def init_flickr(sender):
     'FLICKR_API_KEY' : {
       'mandatory' : True,
     },
+    'FLICKR_API_SECRET' : {
+      'mandatory' : False,
+      'default' : None,
+    },
     'FLICKR_USER' : {
       'mandatory' : True,
     },
@@ -42,6 +46,10 @@ def init_flickr(sender):
       'default' : True,
     },
     'FLICKR_SETS_EXCLUDE' : {
+      'mandatory' : False,
+      'default' : None,
+    },
+    'FLICKR_SETS_INCLUDE' : {
       'mandatory' : False,
       'default' : None,
     },


### PR DESCRIPTION
The standard flickrapi code will only pull down 10 photo sets and the photos included in those sets seem restricted. I have added code to handle standard Flickr API authentication. All you have to do is include the API Secret in the settings. You get a one time authentication web page. You are then prompted to press ENTER to continue.

I have also added a FLICKR_SETS_INCLUDE setting. This take precedence over the EXCLUDE counterpart and allows the user to choose the photo sets they want to include.
